### PR TITLE
Added stratification to train test split.

### DIFF
--- a/mosquito_classification_v1.ipynb
+++ b/mosquito_classification_v1.ipynb
@@ -23,6 +23,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay, f1_score\n",
+    "from sklearn.model_selection import train_test_split\n",
     "import numpy as np\n",
     "import PIL\n",
     "\n",
@@ -118,8 +119,12 @@
    "outputs": [],
    "source": [
     "annotations_df = pd.read_csv(annotations_csv)\n",
-    "train_df = annotations_df.sample(frac=0.8, random_state=200)\n",
-    "val_df = annotations_df.drop(train_df.index)\n",
+    "train_df, val_df = train_test_split(annotations_df, \n",
+    "                                    test_size=0.2, \n",
+    "                                    stratify=annotations_df['class_label'], \n",
+    "                                    random_state=200)\n",
+    "# train_df = annotations_df.sample(frac=0.8, random_state=200)\n",
+    "# val_df = annotations_df.drop(train_df.index)\n",
     "\n",
     "\n",
     "train_dataset = dl.SimpleClassificationDataset(\n",
@@ -532,7 +537,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I think the performance mismatch is due to the splitting.

Since metric is macro f1 (the averages of the f1 scores over the classes), if we split randomly, we might not have examples in our val set that are from one of the minority classes. Sklearns train_test_split has the "stratify" option to counteract that.

Not tested yet though. 